### PR TITLE
Add output for coverage.json and License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+This software is released under the MIT license:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var ISTANBUL = require('istanbul'),
-
+    fs = require('fs'),
     Report = ISTANBUL.Report,
     Collector = ISTANBUL.Collector;
 
@@ -16,21 +16,30 @@ exports = module.exports = Istanbul;
  */
 function Istanbul(runner) {
 
-    runner.on('end', function(){
+    runner.on('end', function () {
 
-        var reporters;
+        var reporters,
+            coverage;
         if (process.env.ISTANBUL_REPORTERS) {
             reporters = process.env.ISTANBUL_REPORTERS.split(',');
         } else {
             reporters = ['text-summary', 'html'];
         }
+        if (process.env.ISTANBUL_COVERAGE) {
+            coverage = process.env.ISTANBUL_COVERAGE;
+        } else {
+            coverage = 'coverage.json';
+        }
 
         var cov = global.__coverage__ || {},
             collector = new Collector();
 
-        collector.add(cov);
 
-        reporters.forEach(function(reporter) {
+        collector.add(cov);
+        //Write coverage.json
+        fs.writeFileSync(coverage, JSON.stringify(cov), 'utf8');
+
+        reporters.forEach(function (reporter) {
             Report.create(reporter).writeReport(collector, true);
         });
 


### PR DESCRIPTION
Hello arikon, I would also like to generate coverage.json .
So I add some code for you.
Aslo. I add a MIT license which is missing but it is declared in https://npmjs.org/package/mocha-istanbul
